### PR TITLE
[codex] Fix shell-quote Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18363,7 +18363,7 @@
         "prompts": "2.4.0",
         "react-error-overlay": "^6.0.9",
         "recursive-readdir": "2.2.2",
-        "shell-quote": "1.7.2",
+        "shell-quote": "1.8.4",
         "strip-ansi": "6.0.0",
         "text-table": "0.2.0"
       },
@@ -19980,9 +19980,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
-      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT"
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,12 @@
   "devDependencies": {
     "prettier": "2.0.5"
   },
+  "overrides": {
+    "shell-quote": "1.8.4"
+  },
+  "resolutions": {
+    "shell-quote": "1.8.4"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby-starter-hello-world"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9771,7 +9771,7 @@ react-dev-utils@^11.0.3:
     prompts "2.4.0"
     react-error-overlay "^6.0.9"
     recursive-readdir "2.2.2"
-    shell-quote "1.7.2"
+    shell-quote "1.8.4"
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
@@ -10678,10 +10678,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.7.2:
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz"
-  integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+shell-quote@1.8.4:
+  version "1.8.4"
+  resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 side-channel-list@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary
- Force shell-quote to patched version 1.8.4 via npm overrides and Yarn resolutions
- Update package-lock.json and yarn.lock entries for the transitive react-dev-utils dependency
- Addresses GitHub Dependabot alerts for shell-quote, including GHSA-w7jw-789q-3m8p

## Verification
- npm ci --ignore-scripts
- node -p "require('./node_modules/shell-quote/package.json').version" -> 1.8.4
- npm audit --json | Select-String -Pattern 'shell-quote|GHSA-w7jw-789q-3m8p|GHSA-g4rg-993r-mgx7' returned no matches
- npm rebuild sharp --foreground-scripts
- $env:NODE_OPTIONS='--openssl-legacy-provider --no-deprecation'; node .\node_modules\gatsby\cli.js build --verbose

Note: GitHub Dependabot could not generate the update because it reported /yarn.lock not parseable, so this PR applies the minimal lockfile update manually.